### PR TITLE
Fix data preparation in read‑only environments

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,12 +2,15 @@ import gradio as gr, subprocess, pathlib, shutil, uuid, os
 from prepare_data import prepare_data_structure
 
 SRC = pathlib.Path(__file__).parent / "src"
-TMP = pathlib.Path("/tmp/space")  # temporäre Arbeits­verzeichnisse
+# Directory used for intermediate results and generated CSVs. It defaults to
+# ``/tmp/space`` but can be overridden via the ``SLDEA_WORKDIR`` environment
+# variable to allow running in read-only locations.
+TMP = pathlib.Path(os.getenv("SLDEA_WORKDIR", "/tmp/space"))
 TMP.mkdir(parents=True, exist_ok=True)
 
 
 # ---------- Hilfsfunktionen ----------
-def _run_notebook(ipynb_path, out_dir, input_csv=None):
+def _run_notebook(ipynb_path, out_dir, input_csv=None, cwd=None):
     """Führt ein Notebook headless aus und legt Ergebnis-CSV in out_dir ab.
 
     Wenn ``input_csv`` angegeben ist, wird der Pfad als Parameter ``input_csv``
@@ -22,7 +25,7 @@ def _run_notebook(ipynb_path, out_dir, input_csv=None):
     if input_csv:
         cmd += ["-p", "input_csv", str(input_csv)]
 
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, cwd=cwd)
     return output_name
 
 
@@ -30,14 +33,14 @@ def _run_notebook(ipynb_path, out_dir, input_csv=None):
 def preprocess(csv_file):
     prepare_data_structure()
     ipynb = SRC / "dialogue_pred.ipynb"  # anpassen, falls dein Notebook anders heißt
-    result = _run_notebook(ipynb, TMP, csv_file.name if csv_file else None)
+    result = _run_notebook(ipynb, TMP, csv_file.name if csv_file else None, cwd=TMP)
     return gr.File(result)
 
 
 def train(processed_csv):
     prepare_data_structure()
     ipynb = SRC / "ESL_AddedExperinments.ipynb"
-    result = _run_notebook(ipynb, TMP, processed_csv.name if processed_csv else None)
+    result = _run_notebook(ipynb, TMP, processed_csv.name if processed_csv else None, cwd=TMP)
     return gr.File(result)
 
 
@@ -55,6 +58,7 @@ def infer(model_pkl, test_csv):
             "--out",
             output_csv,
         ],
+        cwd=TMP,
     )
     return gr.File(output_csv)
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -6,11 +6,19 @@ import pandas as pd
 SRC = Path(__file__).parent / "src"
 DATA_DIR = SRC / "SLDEA Data"
 
-ANNOTATIONS = [SRC / f"annotations({i}).csv" for i in range(1, 6)]
-SAMPLE_DIR = SRC / "data_csv_sample"
+# Directory used for generated CSV files. On platforms where the repository
+# itself is read-only (e.g. HuggingFace Spaces), we fall back to a writable
+# location under ``/tmp``. The path can be overridden via the ``SLDEA_WORKDIR``
+# environment variable so that the notebooks and scripts can locate their
+# input/output in a consistent place.
+WORKDIR = Path(os.getenv("SLDEA_WORKDIR", "/tmp/space"))
+
+ANNOTATIONS = [WORKDIR / f"annotations({i}).csv" for i in range(1, 6)]
+SAMPLE_DIR = WORKDIR / "data_csv_sample"
 
 
 def _convert_excel_to_csv():
+    WORKDIR.mkdir(parents=True, exist_ok=True)
     xlsx_files = sorted(DATA_DIR.glob("*.xlsx"))
     if not xlsx_files:
         raise FileNotFoundError(f"No .xlsx files found in {DATA_DIR}")
@@ -27,7 +35,7 @@ def _convert_excel_to_csv():
 
 
 def _populate_sample_dir():
-    SAMPLE_DIR.mkdir(exist_ok=True)
+    SAMPLE_DIR.mkdir(parents=True, exist_ok=True)
     for csv in DATA_DIR.glob("*.csv"):
         shutil.copy(csv, SAMPLE_DIR / csv.name)
 


### PR DESCRIPTION
## Summary
- write generated CSVs into a writable workdir (`/tmp/space` by default)
- run notebooks and scripts from that workdir so relative paths resolve

## Testing
- `python -m py_compile app.py prepare_data.py`