### PR TITLE
Fix Matplotlib config directory

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,11 @@
 import gradio as gr, subprocess, pathlib, shutil, uuid, os
 from prepare_data import prepare_data_structure
 
+# Ensure Matplotlib writes its config to a writable directory. This is useful in
+# read-only environments such as Docker containers.
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
+pathlib.Path("/tmp/matplotlib").mkdir(parents=True, exist_ok=True)
+
 SRC = pathlib.Path(__file__).parent / "src"
 # Directory used for intermediate results and generated CSVs. It defaults to
 # ``/tmp/space`` but can be overridden via the ``SLDEA_WORKDIR`` environment


### PR DESCRIPTION
## Summary
- ensure Matplotlib config dir is created at runtime so Spaces can run in read-only environments

## Testing
- `python -m py_compile app.py`
- `pytest -q` *(fails: command not found)*