### PR TITLE
Enable multi-file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ SLEDA is a three-level framework for evaluating English Second Language (ESL) co
 
 ## Dataset
 
-Only a small sample of the full SLDEA dataset is provided here. For complete access contact `rena.gao@unimelb.edu.au`. Place the files under `src/SLDEA Data/` so that the notebooks can locate them.
+Only a small sample of the full SLDEA dataset is provided here. For complete access contact `rena.gao@unimelb.edu.au`. Place the files under `src/SLDEA Data/` so that the notebooks can locate them or upload your own Excel/CSV files in the web interface.
 
 ## Working directory
 
-Both `app.py` and `prepare_data.py` write their intermediate results and the generated annotation CSV files to a directory controlled by the `SLDEA_WORKDIR` environment variable. If the variable is not set, `/tmp/space` is used by default. At least five Excel files must be present in `src/SLDEA Data/` so that `prepare_data.py` can produce the required `annotations(1).csv`–`annotations(5).csv` files. The script runs automatically when the application starts, but you can also invoke it manually:
+Both `app.py` and `prepare_data.py` write their intermediate results and the generated annotation CSV files to a directory controlled by the `SLDEA_WORKDIR` environment variable. If the variable is not set, `/tmp/space` is used by default. When running the web interface you may upload any number of Excel/CSV files which are placed in this directory automatically. If you run `prepare_data.py` manually, make sure at least five Excel files reside in `src/SLDEA Data/` so that the helper can build `annotations(1).csv`–`annotations(5).csv`.
 
 ```bash
 python prepare_data.py
@@ -64,8 +64,8 @@ This exposes a Gradio interface on http://localhost:7860.
 
 Create a new **Docker** Space on HuggingFace and link it to this repository. The Space builder uses `Dockerfile` in the repository root to install the dependencies, convert the notebooks to scripts and start `app.py`. Once built, the web interface offers three tabs:
 
-1. **Pre-processing** – execute `dialogue_pred.ipynb` on the prepared sample
-   CSV data. The upload field is ignored.
+1. **Pre-processing** – upload one or more Excel/CSV files and execute
+   `dialogue_pred.ipynb` on the converted data.
 2. **Training** – execute `ESL_AddedExperinments.ipynb`.
 3. **Application** – apply a trained model to new data via `dialogue_pred.py`.
 

--- a/app.py
+++ b/app.py
@@ -28,8 +28,15 @@ def _run_notebook(ipynb_path, out_dir, cwd=None):
 
 
 # ---------- Gradio Callbacks ----------
-def preprocess(csv_file):
-    prepare_data_structure()
+def preprocess(upload_files):
+    uploads_dir = TMP / "uploads"
+    if uploads_dir.exists():
+        shutil.rmtree(uploads_dir)
+    uploads_dir.mkdir(parents=True)
+    for f in upload_files:
+        shutil.copy(f.name, uploads_dir / pathlib.Path(f.name).name)
+
+    prepare_data_structure(uploads_dir, force=True)
     ipynb = SRC / "dialogue_pred.ipynb"  # anpassen, falls dein Notebook anders heißt
     result = _run_notebook(ipynb, TMP, cwd=TMP)
     return gr.File(result)
@@ -64,10 +71,10 @@ def infer(model_pkl, test_csv):
 # ---------- GUI ----------
 with gr.Blocks() as demo:
     with gr.Tab("Pre-processing"):
-        in_file = gr.File(label="Roh-CSV hochladen")
+        in_files = gr.Files(label="Excel/CSV hochladen")
         btn = gr.Button("Start")
         out_file = gr.File(label="Ergebnis-Notebook")
-        btn.click(preprocess, in_file, out_file)
+        btn.click(preprocess, in_files, out_file)
 
     with gr.Tab("Training"):
         proc = gr.File(label="Vorverarbeitete CSV")

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -17,34 +17,46 @@ ANNOTATIONS = [WORKDIR / f"annotations({i}).csv" for i in range(1, 6)]
 SAMPLE_DIR = WORKDIR / "data_csv_sample"
 
 
-def _convert_excel_to_csv():
+def _convert_excel_to_csv(data_dir: Path):
+    """Convert uploaded Excel/CSV files to the 5 ``annotations`` CSV files."""
     WORKDIR.mkdir(parents=True, exist_ok=True)
-    xlsx_files = sorted(DATA_DIR.glob("*.xlsx"))
-    if not xlsx_files:
-        raise FileNotFoundError(f"No .xlsx files found in {DATA_DIR}")
-    # Partition files into 5 roughly equal groups
-    part_size = (len(xlsx_files) + 4) // 5
+    xlsx_files = sorted(data_dir.glob("*.xlsx"))
+    csv_files = sorted(data_dir.glob("*.csv"))
+    frames = []
+    for p in xlsx_files:
+        frames.append(pd.read_excel(p))
+    for p in csv_files:
+        frames.append(pd.read_csv(p))
+    if not frames:
+        raise FileNotFoundError(f"No .xlsx or .csv files found in {data_dir}")
+
+    part_size = (len(frames) + 4) // 5
     for idx, ann_path in enumerate(ANNOTATIONS):
         start = idx * part_size
         end = start + part_size
-        subset = xlsx_files[start:end]
+        subset = frames[start:end]
         if not subset:
             break
-        df = pd.concat(pd.read_excel(p) for p in subset)
+        df = pd.concat(subset)
         ann_path.write_text(df.to_csv(index=False))
 
 
-def _populate_sample_dir():
+def _populate_sample_dir(data_dir: Path):
+    """Copy CSV files (or converted XLSX files) into ``data_csv_sample``."""
     SAMPLE_DIR.mkdir(parents=True, exist_ok=True)
-    for csv in DATA_DIR.glob("*.csv"):
+    for csv in data_dir.glob("*.csv"):
         shutil.copy(csv, SAMPLE_DIR / csv.name)
+    for xlsx in data_dir.glob("*.xlsx"):
+        df = pd.read_excel(xlsx)
+        (SAMPLE_DIR / f"{xlsx.stem}.csv").write_text(df.to_csv(index=False))
 
 
-def prepare_data_structure():
-    if all(p.exists() for p in ANNOTATIONS) and SAMPLE_DIR.exists():
+def prepare_data_structure(data_dir: Path = DATA_DIR, force: bool = False):
+    """Ensure the workspace contains the CSVs required by the notebooks."""
+    if not force and all(p.exists() for p in ANNOTATIONS) and SAMPLE_DIR.exists():
         return
-    _convert_excel_to_csv()
-    _populate_sample_dir()
+    _convert_excel_to_csv(data_dir)
+    _populate_sample_dir(data_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support multi-file uploads in preprocessing step
- handle uploaded Excel/CSV files when building annotation CSVs
- document the new workflow

## Testing
- `python -m py_compile app.py prepare_data.py`
- `python prepare_data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*