### PR TITLE
Set MPLCONFIGDIR early

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,9 @@
-import gradio as gr, subprocess, pathlib, shutil, uuid, os, pandas as pd
-from prepare_data import prepare_data_structure
-
-# Ensure Matplotlib writes its config to a writable directory. This is useful in
-# read-only environments such as Docker containers.
+import pathlib, os
 os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
 pathlib.Path("/tmp/matplotlib").mkdir(parents=True, exist_ok=True)
+
+import gradio as gr, subprocess, shutil, uuid, pandas as pd
+from prepare_data import prepare_data_structure
 
 SRC = pathlib.Path(__file__).parent / "src"
 # Directory used for intermediate results and generated CSVs. It defaults to


### PR DESCRIPTION
## Summary
- set `MPLCONFIGDIR` before importing any modules that may load Matplotlib

## Testing
- `python -m py_compile app.py`